### PR TITLE
Update Barcelona Mathematical Days 2026 details

### DIFF
--- a/content/posts/barcelona-mathemtical-days-2026.md
+++ b/content/posts/barcelona-mathemtical-days-2026.md
@@ -1,0 +1,28 @@
++++ 
+title = "Barcelona Mathematical Days, October 7-9, 2026" 
+date = "2026-07-20 10:30:00" 
+categories = ["news", "events"] 
++++
+
+The fifth edition of the [**Barcelona Mathematical Days (BMD 2026)**](https://scm.iec.cat/eng/congres/bmd-2026/) will take place at the **Institut d'Estudis Catalans in Barcelona** from **October 7 to 9, 2026**.
+
+BMD is the triennial international research conference of the Catalan Mathematical Society and covers a broad range of current topics in mathematics.
+
+The plenary speakers will be:
+
+- Marco Abate (University of Pisa)
+- Ruth Charney (Brandeis University)
+- Dan Crisan (Imperial College London)
+- Xavier Ros-Oton (University of Barcelona)
+
+The program will also include eight thematic sessions, covering combinatorics, dynamical systems, group theory, analysis and PDEs, mathematical modeling, arithmetic geometry, stochastic analysis, and topological data analysis. A special session connected with **MOSS**, the Mathematics Online Seminar Series of the EMS Young Academy, will also be held.
+
+Early-career researchers, especially PhD students and postdoctoral fellows, are encouraged to participate and present a poster.
+
+- **Poster submission deadline:** July 31, 2026
+- **Early-registration deadline:** September 4, 2026
+- **Final registration deadline:** September 30, 2026
+
+Further information on the program, registration, accommodation, and poster submissions is available on the conference website:
+
+<https://scm.iec.cat/eng/congres/bmd-2026/>


### PR DESCRIPTION
Added details about the Barcelona Mathematical Days 2026 conference, including speakers, sessions, and deadlines.